### PR TITLE
[고도화] DB Migration(MySQL to PostgreSQL)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,10 +15,10 @@ spring:
 spring:
   config.activate.on-profile: local
   datasource:
-    url: jdbc:mysql://localhost:3306/board
+    url: jdbc:postgresql://localhost:5432/board
     username: artist
-    password: thisisTESTpw!#%&
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    password: artist
+    driver-class-name:
   jpa:
     open-in-view : false
     defer-datasource-initialization: true


### PR DESCRIPTION
JPA의 이점을 활용하여, 간단하게 프로젝트 DB를 MySQL → PostgreSQL로 전환 성공.

This closes #76 