### PR TITLE
[고도화] 해시태그 검색 기능 고도화

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
@@ -41,6 +41,7 @@ public class ArticleController {
         map.addAttribute("articles", articles);
         map.addAttribute("paginationBarNumbers", barNumbers);
         map.addAttribute("searchTypes", SearchType.values());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/index";
     }
@@ -52,6 +53,7 @@ public class ArticleController {
         map.addAttribute("article", article);
         map.addAttribute("articleComments", article.articleCommentsResponse());
         map.addAttribute("totalCount", articleService.getArticleCount());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/detail";
     }

--- a/src/main/java/com/fastcampus/projectboard/service/ArticleService.java
+++ b/src/main/java/com/fastcampus/projectboard/service/ArticleService.java
@@ -1,11 +1,13 @@
 package com.fastcampus.projectboard.service;
 
 import com.fastcampus.projectboard.domain.Article;
+import com.fastcampus.projectboard.domain.Hashtag;
 import com.fastcampus.projectboard.domain.UserAccount;
 import com.fastcampus.projectboard.domain.constant.SearchType;
 import com.fastcampus.projectboard.dto.ArticleDto;
 import com.fastcampus.projectboard.dto.ArticleWithCommentsDto;
 import com.fastcampus.projectboard.repository.ArticleRepository;
+import com.fastcampus.projectboard.repository.HashtagRepository;
 import com.fastcampus.projectboard.repository.UserAccountRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityNotFoundException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -24,8 +28,10 @@ import java.util.List;
 @Service
 public class ArticleService {
 
+    private final HashtagService hashtagService;
     private final ArticleRepository articleRepository;
     private final UserAccountRepository userAccountRepository;
+    private final HashtagRepository hashtagRepository;
 
     @Transactional(readOnly = true)
     public Page<ArticleDto> searchArticles(SearchType searchType, String searchKeyword, Pageable pageable) {
@@ -58,7 +64,12 @@ public class ArticleService {
 
     public void saveArticle(ArticleDto dto) {
         UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
-        articleRepository.save(dto.toEntity(userAccount));
+        Set<Hashtag> hashtags = renewHashtagsFromContent(dto.content());
+
+        Article article = dto.toEntity(userAccount);
+        article.addHashtags(hashtags);
+
+        articleRepository.save(article);
     }
 
     public void updateArticle(Long articleId, ArticleDto dto) {
@@ -69,6 +80,17 @@ public class ArticleService {
             if (article.getUserAccount().equals(userAccount)) {
                 if (dto.title() != null) { article.setTitle(dto.title()); }
                 if (dto.content() != null) { article.setContent(dto.content()); }
+
+                Set<Long> hashtagIds = article.getHashtags().stream()
+                        .map(Hashtag::getId)
+                        .collect(Collectors.toUnmodifiableSet());
+                article.clearHashtags();
+                articleRepository.flush();
+
+                hashtagIds.forEach(hashtagService::deleteHashtagWithoutArticles);
+
+                Set<Hashtag> hashtags = renewHashtagsFromContent(dto.content());
+                article.addHashtags(hashtags);
             }
         } catch (EntityNotFoundException e) {
             log.warn("게시글 업데이트 실패. 게시글을 수정하는데 필요한 정보를 찾을 수 없습니다 - {}", e.getLocalizedMessage());
@@ -76,7 +98,15 @@ public class ArticleService {
     }
 
     public void deleteArticle(long articleId, String userId) {
+        Article article = articleRepository.getReferenceById(articleId);
+        Set<Long> hashtagIds = article.getHashtags().stream()
+                .map(Hashtag::getId)
+                .collect(Collectors.toUnmodifiableSet());
+
         articleRepository.deleteByIdAndUserAccount_UserId(articleId, userId);
+        articleRepository.flush();
+
+        hashtagIds.forEach(hashtagService::deleteHashtagWithoutArticles);
     }
 
     public long getArticleCount() {
@@ -84,16 +114,32 @@ public class ArticleService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ArticleDto> searchArticlesViaHashtag(String hashtag, Pageable pageable) {
-        if (hashtag == null || hashtag.isBlank()) {
+    public Page<ArticleDto> searchArticlesViaHashtag(String hashtagName, Pageable pageable) {
+        if (hashtagName == null || hashtagName.isBlank()) {
             return Page.empty(pageable);
         }
 
-        return articleRepository.findByHashtagNames(null, pageable).map(ArticleDto::from);
+        return articleRepository.findByHashtagNames(List.of(hashtagName), pageable).map(ArticleDto::from);
     }
 
     public List<String> getHashtags() {
-        return articleRepository.findAllDistinctHashtags();
+        return hashtagRepository.findAllHashtagNames();     // TODO: HashtagService 로 이동을 고려해보자.
+    }
+
+    private Set<Hashtag> renewHashtagsFromContent(String content){
+        Set<String> hashtagNamesInContext = hashtagService.parseHashtagNames(content);
+        Set<Hashtag> hashtags = hashtagService.findHashtagsByNames(hashtagNamesInContext);
+        Set<String> existingHashtagNames = hashtags.stream()
+                .map(Hashtag::getHashtagName)
+                .collect(Collectors.toUnmodifiableSet());
+
+        hashtagNamesInContext.forEach(newHashtagName -> {
+            if(!existingHashtagNames.contains(newHashtagName)){
+                hashtags.add(Hashtag.of(newHashtagName));
+            }
+        });
+
+        return hashtags;
     }
 
 }

--- a/src/main/java/com/fastcampus/projectboard/service/HashtagService.java
+++ b/src/main/java/com/fastcampus/projectboard/service/HashtagService.java
@@ -1,19 +1,45 @@
 package com.fastcampus.projectboard.service;
 
+import com.fastcampus.projectboard.domain.Hashtag;
+import com.fastcampus.projectboard.repository.HashtagRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+@RequiredArgsConstructor
 @Service
 public class HashtagService {
-    public Object parseHashtagNames(String content) {
-        return null;
+
+    private final HashtagRepository hashtagRepository;
+
+    public Set<String> parseHashtagNames(String content) {
+        if(content == null){
+            return Set.of();
+        }
+
+        Pattern pattern = Pattern.compile("#[\\w가-힣]+");
+        Matcher matcher = pattern.matcher(content.strip());
+        Set<String> result = new HashSet<>();
+
+        while (matcher.find()){
+            result.add(matcher.group().replace("#", ""));
+        }
+
+        return Set.copyOf(result);
     }
 
-    public Object findHashtagsByNames(Set<String> expectedHashtagNames) {
-        return null;
+    public Set<Hashtag> findHashtagsByNames(Set<String> hashtagNames) {
+        return new HashSet<>(hashtagRepository.findByHashtagNameIn(hashtagNames));
     }
 
-    public void deleteHashtagWithoutArticles(Object any) {
+    public void deleteHashtagWithoutArticles(Long hashtagId) {
+        Hashtag hashtag = hashtagRepository.getReferenceById(hashtagId);
+        if(hashtag.getArticles().isEmpty()){
+            hashtagRepository.delete(hashtag);
+        }
     }
 }

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -29,7 +29,7 @@
                     <p><span id="nickname">Artist</span></p>
                     <p><a id="email" href="mailto:artist@gmail.com">artist@mail.com</a></p>
                     <p><time id="created-at" datetime="2022-01-01T00:00:00">2022-01-01</time></p>
-                    <p><span id="hashtag">#java</span></p>
+                    <p><span id="hashtag" class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></p>
                 </aside>
             </section>
 

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -8,7 +8,12 @@
         <attr sel="#nickname" th:text="*{nickname}" />
         <attr sel="#email" th:text="*{email}" />
         <attr sel="#created-at" th:datetime="*{createdAt}" th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
-        <attr sel="#hashtag" th:text="*{hashtag}" />
+        <attr sel="#hashtag" th:each="hashtag : ${article.hashtags}">
+            <attr sel="a"
+                  th:text="'#' + ${hashtag}"
+                  th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"
+            />
+        </attr>
         <attr sel="#article-content/pre" th:text="*{content}" />
 
         <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">

--- a/src/main/resources/templates/articles/form.html
+++ b/src/main/resources/templates/articles/form.html
@@ -35,12 +35,6 @@
           <textarea class="form-control" id="content" name="content" rows="5" required></textarea>
         </div>
       </div>
-      <div class="row mb-4 justify-content-md-center">
-        <label for="hashtag" class="col-sm-2 col-lg-1 col-form-label text-sm-end">해시태그</label>
-        <div class="col-sm-8 col-lg-9">
-          <input type="text" class="form-control" id="hashtag" name="hashtag">
-        </div>
-      </div>
       <div class="row mb-5 justify-content-md-center">
         <div class="col-sm-10 d-grid gap-2 d-sm-flex justify-content-sm-end">
           <button type="submit" class="btn btn-primary" id="submit-button">저장</button>

--- a/src/main/resources/templates/articles/form.th.xml
+++ b/src/main/resources/templates/articles/form.th.xml
@@ -8,7 +8,6 @@
   <attr sel="#article-form" th:action="${formStatus?.update} ? '/articles/' + ${article.id} + '/form' : '/articles/form'" th:method="post">
     <attr sel="#title" th:value="${article?.title} ?: _" />
     <attr sel="#content" th:text="${article?.content} ?: _" />
-    <attr sel="#hashtag" th:value="${article?.hashtag} ?: _" />
     <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
     <attr sel="#cancel-button" th:onclick="'history.back()'" />
   </attr>

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -71,7 +71,7 @@
                 <tbody>
                 <tr>
                     <td class="title"><a>첫글</a></td>
-                    <td class="hashtag">#java</td>
+                    <td class="hashtag"><span class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></td>
                     <td class="user-id">artist</td>
                     <td class="created-at"><time>2022-01-01</time></td>
                 </tr>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -24,7 +24,7 @@
             )}"/>
                 <attr sel="th.hashtag/a" th:text="'해시태그'" th:href="@{/articles(
                 page=${articles.number},
-                sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                sort='hashtags' + (*{sort.getOrderFor('hashtags')} != null ? (*{sort.getOrderFor('hashtags').direction.name} != 'DESC' ? ',desc' : '') : ''),
                 searchType=${param.searchType}, searchValue=${param.searchValue}
             )}"/>
                 <attr sel="th.user-id/a" th:text="'작성자'" th:href="@{/articles(

--- a/src/test/java/com/fastcampus/projectboard/service/HashtagServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/HashtagServiceTest.java
@@ -1,0 +1,106 @@
+package com.fastcampus.projectboard.service;
+
+import com.fastcampus.projectboard.domain.Hashtag;
+import com.fastcampus.projectboard.repository.HashtagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("비즈니스 로직 - 해시태그")
+@ExtendWith(MockitoExtension.class)
+class HashtagServiceTest {
+
+    @InjectMocks private HashtagService sut;
+
+    @Mock private HashtagRepository hashtagRepository;
+
+
+    @DisplayName("본문을 파싱하면, 해시태그 이름들을 중복 없이 반환한다.")
+    @MethodSource
+    @ParameterizedTest(name = "[{index}] \"{0}\" => {1}")
+    void givenContent_whenParsing_thenReturnsUniqueHashtagNames(String input, Set<String> expected){
+        // Given
+
+        // When
+        Set<String> actual = sut.parseHashtagNames(input);
+
+        //Then
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+        then(hashtagRepository).shouldHaveNoInteractions();
+    }
+
+    static Stream<Arguments> givenContent_whenParsing_thenReturnsUniqueHashtagNames(){
+        return Stream.of(
+                arguments(null, Set.of()),
+                arguments("", Set.of()),
+                arguments("   ", Set.of()),
+                arguments("#", Set.of()),
+                arguments("  #", Set.of()),
+                arguments("#   ", Set.of()),
+                arguments("java", Set.of()),
+                arguments("java#", Set.of()),
+                arguments("ja#va", Set.of("va")),
+                arguments("#java", Set.of("java")),
+                arguments("#java_spring", Set.of("java_spring")),
+                arguments("#java-spring", Set.of("java")),
+                arguments("#_java_spring", Set.of("_java_spring")),
+                arguments("#-java-spring", Set.of()),
+                arguments("#_java_spring__", Set.of("_java_spring__")),
+                arguments("#java#spring", Set.of("java", "spring")),
+                arguments("#java #spring", Set.of("java", "spring")),
+                arguments("#java  #spring", Set.of("java", "spring")),
+                arguments("#java   #spring", Set.of("java", "spring")),
+                arguments("#java     #spring", Set.of("java", "spring")),
+                arguments("  #java     #spring ", Set.of("java", "spring")),
+                arguments("   #java     #spring   ", Set.of("java", "spring")),
+                arguments("#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java #spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#spring #부트", Set.of("java", "spring", "부트")),
+                arguments("#java,#spring,#부트", Set.of("java", "spring", "부트")),
+                arguments("#java.#spring;#부트", Set.of("java", "spring", "부트")),
+                arguments("#java|#spring:#부트", Set.of("java", "spring", "부트")),
+                arguments("#java #spring  #부트", Set.of("java", "spring", "부트")),
+                arguments("   #java,? #spring  ...  #부트 ", Set.of("java", "spring", "부트")),
+                arguments("#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#spring#java#부트#java", Set.of("java", "spring", "부트")),
+                arguments("#java#스프링 아주 긴 글~~~~~~~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~~~~~~~~~~~~~~~~#java#스프링", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~#java#스프링~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~#java~~~~~~~#스프링~~~~~~~~", Set.of("java", "스프링"))
+        );
+    }
+
+    @DisplayName("해시태그 이름들을 입력하면, 저장된 해시태그 중 이름에 매칭하는 것들을 중복 없이 반환한다.")
+    @Test
+    void givenHashtagNames_whenFindingHashtags_thenReturnsHashtagSet() {
+        // Given
+        Set<String> hashtagNames = Set.of("java", "spring", "boots");
+        given(hashtagRepository.findByHashtagNameIn(hashtagNames)).willReturn(List.of(
+                Hashtag.of("java"),
+                Hashtag.of("spring")
+        ));
+
+        // When
+        Set<Hashtag> hashtags = sut.findHashtagsByNames(hashtagNames);
+
+        // Then
+        assertThat(hashtags).hasSize(2);
+        then(hashtagRepository).should().findByHashtagNameIn(hashtagNames);
+    }
+}


### PR DESCRIPTION
해시태그 기능을 고도화하는 작업을 완료하였다.

작업 내역
* 하나의 글이 여러 개의 해시태그를 저장할 수 있도록 만들기
* 별도 입력 공간을 주지 않고, 본문에서 해시태그를 파싱해서 기록하기
* DB에는 #을 뺀 문자열을 저장할 수 있게 하기
* 해시태그에 링크를 삽입하기

This closes #77 